### PR TITLE
fix akmod only build

### DIFF
--- a/nvidia-kmod.spec
+++ b/nvidia-kmod.spec
@@ -16,7 +16,7 @@
 
 %define __mod_compress_install_post \
   if [ "%{zipmodules}" -eq "1" ]; then \
-    find %{buildroot}/usr/lib/modules/ -type f -name '*.ko' | xargs xz; \
+    find %{buildroot}/usr/lib/modules/ -type f -name '*.ko' | xargs xz &> /dev/null || : \
   fi
 
 Name:           nvidia-kmod


### PR DESCRIPTION
```
$ rpmbuild --rebuild /home/leigh/Desktop/nvidia-kmod/nvidia-kmod-364.19-3.fc24.src.rpm
Installing /home/leigh/Desktop/nvidia-kmod/nvidia-kmod-364.19-3.fc24.src.rpm
Executing(%prep): /bin/sh -e /var/tmp/rpm-tmp.K0LeUX
+ umask 022
+ cd /home/leigh/development/rpmbuild/BUILD
+ kmodtool --target x86_64 --repo rpmfusion --kmodname nvidia-kmod --filterfile /home/leigh/development/rpmbuild/SOURCES/nvidia-kmodtool-excludekernel-filterfile --obsolete-name nvidia-newest --obsolete-version 364.19 --akmod


%global akmod_install mkdir -p $RPM_BUILD_ROOT/%{_usrsrc}/akmods/; \rpmbuild --define "_sourcedir %{_sourcedir}" \--define "_srcrpmdir $RPM_BUILD_ROOT/%{_usrsrc}/akmods/" \-bs --nodeps %{_specdir}/%{name}.spec ; \ln -s $(ls $RPM_BUILD_ROOT/%{_usrsrc}/akmods/) $RPM_BUILD_ROOT/%{_usrsrc}/akmods/nvidia-kmod.latest

%package -n akmod-nvidia
Summary:    Akmod package for nvidia kernel module(s) 
Group:      System Environment/Kernel
Requires:   kmodtool
Requires:   akmods
%{?AkmodsBuildRequires:Requires: %{AkmodsBuildRequires}}
# same requires and provides as a kmods package would have
Requires:   nvidia-kmod-common >= %{?epoch:%{epoch}:}%{version}
Provides:   nvidia-kmod = %{?epoch:%{epoch}:}%{version}-%{release}
Provides:   akmod-nvidia-newest = 364.19
Obsoletes:  akmod-nvidia-newest < 364.19

%description -n akmod-nvidia
This package provides the akmod package for the nvidia kernel modules.

%posttrans -n akmod-nvidia
nohup /usr/sbin/akmods --from-akmod-posttrans --akmod nvidia &> /dev/null &

%files -n akmod-nvidia
%defattr(-,root,root,-)
%{_usrsrc}/akmods/*

%package      -n kmod-nvidia
Summary:         Metapackage which tracks in nvidia kernel module for newest kernel
Group:           System Environment/Kernel

Provides:        nvidia-kmod = %{?epoch:%{epoch}:}%{version}-%{release}
Provides:        kmod-nvidia-xen = %{?epoch:%{epoch}:}%{version}-%{release}
Provides:        kmod-nvidia-smp = %{?epoch:%{epoch}:}%{version}-%{release}
Provides:        kmod-nvidia-PAE = %{?epoch:%{epoch}:}%{version}-%{release}
Requires:        akmod-nvidia = %{?epoch:%{epoch}:}%{version}-%{release}
Provides:        kmod-nvidia-newest = 364.19
Obsoletes:       kmod-nvidia-newest < 364.19

%description  -n kmod-nvidia
This is a meta-package without payload which sole purpose is to require the
nvidia kernel module(s) for the newest kernel,
to make sure you get it together with a new kernel.

%files        -n kmod-nvidia
%defattr(644,root,root,755)
+ cd /home/leigh/development/rpmbuild/BUILD
+ rm -rf nvidia-kmod-364.19-x86_64
+ /usr/bin/xz -dc /home/leigh/development/rpmbuild/SOURCES/nvidia-kmod-364.19-i386.tar.xz
+ /usr/bin/tar -xof -
+ STATUS=0
+ '[' 0 -ne 0 ']'
+ /usr/bin/xz -dc /home/leigh/development/rpmbuild/SOURCES/nvidia-kmod-364.19-x86_64.tar.xz
+ /usr/bin/tar -xof -
+ STATUS=0
+ '[' 0 -ne 0 ']'
+ cd nvidia-kmod-364.19-x86_64
+ /usr/bin/chmod -Rf a+rX,u+w,g-w,o-w .
+ echo 'Patch #0 (4.6-kernel.patch):'
Patch #0 (4.6-kernel.patch):
+ /usr/bin/patch -p1 --fuzz=0
patching file kernel/nvidia-drm/nvidia-drm-fb.c
patching file kernel/nvidia-drm/nvidia-drm-fb.h
patching file kernel/nvidia-drm/nvidia-drm-linux.c
+ exit 0
Executing(%build): /bin/sh -e /var/tmp/rpm-tmp.HfVarJ
+ umask 022
+ cd /home/leigh/development/rpmbuild/BUILD
+ cd nvidia-kmod-364.19-x86_64
+ exit 0
Executing(%install): /bin/sh -e /var/tmp/rpm-tmp.qnAK2u
+ umask 022
+ cd /home/leigh/development/rpmbuild/BUILD
+ '[' /home/leigh/development/rpmbuild/BUILDROOT/nvidia-kmod-364.19-3.fc24.x86_64 '!=' / ']'
+ rm -rf /home/leigh/development/rpmbuild/BUILDROOT/nvidia-kmod-364.19-3.fc24.x86_64
++ dirname /home/leigh/development/rpmbuild/BUILDROOT/nvidia-kmod-364.19-3.fc24.x86_64
+ mkdir -p /home/leigh/development/rpmbuild/BUILDROOT
+ mkdir /home/leigh/development/rpmbuild/BUILDROOT/nvidia-kmod-364.19-3.fc24.x86_64
+ cd nvidia-kmod-364.19-x86_64
+ mkdir -p /home/leigh/development/rpmbuild/BUILDROOT/nvidia-kmod-364.19-3.fc24.x86_64//usr/src/akmods/
+ rpmbuild --define '_sourcedir /home/leigh/development/rpmbuild/SOURCES' --define '_srcrpmdir /home/leigh/development/rpmbuild/BUILDROOT/nvidia-kmod-364.19-3.fc24.x86_64//usr/src/akmods/' -bs --nodeps /home/leigh/development/rpmbuild/SPECS/nvidia-kmod.spec
Wrote: /home/leigh/development/rpmbuild/BUILDROOT/nvidia-kmod-364.19-3.fc24.x86_64/usr/src/akmods/nvidia-kmod-364.19-3.fc24.src.rpm
++ ls /home/leigh/development/rpmbuild/BUILDROOT/nvidia-kmod-364.19-3.fc24.x86_64//usr/src/akmods/
+ ln -s nvidia-kmod-364.19-3.fc24.src.rpm /home/leigh/development/rpmbuild/BUILDROOT/nvidia-kmod-364.19-3.fc24.x86_64//usr/src/akmods/nvidia-kmod.latest
+ '[' '%{buildarch}' = noarch ']'
+ QA_CHECK_RPATHS=1
+ case "${QA_CHECK_RPATHS:-}" in
+ /usr/lib/rpm/check-rpaths
+ /usr/lib/rpm/check-buildroot
+ /usr/lib/rpm/brp-compress
+ /usr/lib/rpm/brp-strip /usr/bin/strip
+ /usr/lib/rpm/brp-strip-comment-note /usr/bin/strip /usr/bin/objdump
+ /usr/lib/rpm/brp-strip-static-archive /usr/bin/strip
+ /usr/lib/rpm/brp-python-bytecompile /usr/bin/python 1
+ /usr/lib/rpm/brp-python-hardlink
+ /usr/lib/rpm/redhat/brp-java-repack-jars
+ '[' 1 -eq 1 ']'
+ find /home/leigh/development/rpmbuild/BUILDROOT/nvidia-kmod-364.19-3.fc24.x86_64/usr/lib/modules/ -type f -name '*.ko'
+ xargs xz
find: '/home/leigh/development/rpmbuild/BUILDROOT/nvidia-kmod-364.19-3.fc24.x86_64/usr/lib/modules/': No such file or directory
xz: Compressed data cannot be written to a terminal
xz: Try `xz --help' for more information.
```
