### PR TITLE
Add patches to deal with the new Simple FB / DRM.

### DIFF
--- a/nvidia-kmod-pci-request-regions.patch
+++ b/nvidia-kmod-pci-request-regions.patch
@@ -1,0 +1,21 @@
+diff -up kernel/nvidia/linux_nvswitch.c.orig kernel/nvidia/linux_nvswitch.c
+--- kernel/nvidia/linux_nvswitch.c.orig	2021-12-31 13:53:49.000000000 +0100
++++ kernel/nvidia/linux_nvswitch.c	2022-01-19 13:17:53.955709286 +0100
+@@ -1320,6 +1320,9 @@ nvswitch_probe
+ 
+     pci_set_master(pci_dev);
+ 
++// Don't call pci_request_regions if CONFIG_SYSFB_SIMPLEFB - see also
++// https://patchwork.kernel.org/project/dri-devel/patch/20220117180359.18114-1-zack@kde.org/#24702504
++#if ! defined(CONFIG_SYSFB_SIMPLEFB)
+     rc = pci_request_regions(pci_dev, nvswitch_dev->name);
+     if (rc)
+     {
+@@ -1328,6 +1331,7 @@ nvswitch_probe
+                rc);
+         goto pci_request_regions_failed;
+     }
++#endif
+ 
+     nvswitch_dev->bar0 = pci_iomap(pci_dev, 0, 0);
+     if (!nvswitch_dev->bar0)

--- a/nvidia-kmod-simpledrm.patch
+++ b/nvidia-kmod-simpledrm.patch
@@ -1,0 +1,64 @@
+From b1912480539b4dd23ce8ba901b1a16e915561437 Mon Sep 17 00:00:00 2001
+From: Javier Martinez Canillas <javierm@redhat.com>
+Date: Fri, 18 Feb 2022 13:48:46 +0100
+Subject: [PATCH 1/2] nvidia-drm: remove existing generic drivers to take over
+ the device
+
+There are drivers that register framebuffer devices very early in the boot
+process and make use of the existing framebuffer as setup by the firmware.
+
+If one of those drivers has registered a fbdev, then the fallback fbdev of
+the DRM driver won't be bound to the framebuffer console. To avoid that,
+remove any existing generic driver and take over the graphics device.
+
+By doing that, the fb mapped to the console is switched correctly from the
+early fbdev (i.e: simpledrm) to the one registered by the real DRM drivers.
+
+Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>
+---
+ kernel/nvidia-drm/nvidia-drm-drv.c | 16 ++++++++++++++++
+ 1 file changed, 16 insertions(+)
+
+diff --git a/kernel/nvidia-drm/nvidia-drm-drv.c b/kernel/nvidia-drm/nvidia-drm-drv.c
+index 0d29d1d6bf4d..9149f87b6244 100644
+--- kernel/nvidia-drm/nvidia-drm-drv.c
++++ kernel/nvidia-drm/nvidia-drm-drv.c
+@@ -60,6 +60,8 @@
+ #include <drm/drm_ioctl.h>
+ #endif
+ 
++#include <drm/drm_aperture.h>
++
+ #include <linux/pci.h>
+ 
+ /*
+@@ -897,6 +899,8 @@ static void nv_drm_register_drm_device(const nv_gpu_info_t *gpu_info)
+     struct drm_device *dev = NULL;
+     struct device *device = gpu_info->os_device_ptr;
+ 
++    int ret = 0;
++
+     DRM_DEBUG(
+         "Registering device for NVIDIA GPU ID 0x08%x",
+         gpu_info->gpu_id);
+@@ -917,6 +921,18 @@ static void nv_drm_register_drm_device(const nv_gpu_info_t *gpu_info)
+     mutex_init(&nv_dev->lock);
+ #endif
+ 
++    if (IS_ENABLED(CONFIG_DRM_SIMPLEDRM)) {
++	    /* Remove existing drivers that may own the framebuffer memory. */
++
++	    ret = drm_aperture_remove_framebuffers(false, &nv_drm_driver);
++	    if (ret) {
++		    NV_DRM_DEV_LOG_ERR(nv_dev,
++				       "Failed to remove existing framebuffers - %d.\n",
++				       ret);
++		    return;
++	    }
++    }
++
+     /* Allocate DRM device */
+ 
+     dev = drm_dev_alloc(&nv_drm_driver, device);
+-- 
+2.34.1

--- a/nvidia-kmod.spec
+++ b/nvidia-kmod.spec
@@ -28,7 +28,7 @@
 
 Name:           nvidia-kmod
 Version:        510.68.02
-Release:        1%{?dist}
+Release:        1.1%{?dist}
 Summary:        NVIDIA display driver kernel module
 Epoch:          3
 License:        NVIDIA License
@@ -36,6 +36,9 @@ URL:            http://www.nvidia.com/object/unix.html
 ExclusiveArch:  x86_64
 
 Source0:        %{name}-%{version}-x86_64.tar.xz
+# Support the introduction of the SimpleFB in fc36
+Patch0:         nvidia-kmod-pci-request-regions.patch
+Patch1:         nvidia-kmod-simpledrm.patch
 
 # get the needed BuildRequires (in parts depending on what we build for)
 BuildRequires:  kmodtool
@@ -80,6 +83,9 @@ done
 %{?akmod_install}
 
 %changelog
+* Sat May 14 2022 Steve Storey <sstorey@gmail.com> - 510.68.02-1.1
+- Add patches to deal with the use of SimpleFB in fc36
+
 * Mon May 02 2022 Simone Caronni <negativo17@gmail.com> - 3:510.68.02-1
 - Update to 510.68.02.
 


### PR DESCRIPTION
Fedora 36 has switched from using the older fbdev and efifb dfivers
in favour of using simplefb instead. This is not immediately
compatible with the NVidia kmod however.

These patches are borrowed from the rpmfusion repo with one edit
to allow the patch to be cleanly applied to the negativo17 build
tree.